### PR TITLE
avoid to spawn clean bmports jobs multi times, only at bmgwdriver init.

### DIFF
--- a/neutron/services/bm_gw/common/utils.py
+++ b/neutron/services/bm_gw/common/utils.py
@@ -126,6 +126,10 @@ class BmgwBridge(ovs_lib.OVSBridge):
         # to enable qinq on ovs port, we need to set the following options globally in Open_vSwitch table
         other_config = {'vlan-limit': '2'}
         self.ovsdb.db_set('Open_vSwitch', '.', ('other_config', other_config))
+        #eventlet.spawn_after(60, self.clean_dead_bmports)
+    
+    def spawn_clean_dead_bmports(self):
+        LOG.info("bmgw: spawn job clean_dead_bmports")
         eventlet.spawn_after(60, self.clean_dead_bmports)
 
     def clean_dead_bmports(self):

--- a/neutron/services/bm_gw/drivers/openvswitch/agent/bmgwdriver.py
+++ b/neutron/services/bm_gw/drivers/openvswitch/agent/bmgwdriver.py
@@ -43,6 +43,7 @@ class BmGwDriver(object):
         # and should added the physical NIC (for baremetals access) to it.
         LOG.debug(f"BmGwDriver, init, bm_gw_brname={cfg.CONF.AGENT.bm_gw_brname}")
         self.br_bmgw = utils.BmgwBridge(cfg.CONF.AGENT.bm_gw_brname)
+        self.br_bmgw.spawn_clean_dead_bmports()
         #self.br_bmgw.create(secure_mode=True)
         #self.nic_ofport = self.br_bmgw.add_port(cfg.CONF.AGENT.bm_gw_nic)
         #self.br_bmgw.set_nic_ofport_id(self.nic_ofport)


### PR DESCRIPTION
avoid to spawn clean bmports jobs multi times, only at bmgwdriver init.
Don't need spawn the job at bmport init.